### PR TITLE
agregar .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# carpeta autogenerada por vscode o extensiones de él
+.vscode/


### PR DESCRIPTION
Agregué un archivo .gitignore para que no trackeemos archivos que genera vscode para trabajar en nuestros entornos locales